### PR TITLE
Fix MockServer base url bug

### DIFF
--- a/dist/pact-js-dsl.js
+++ b/dist/pact-js-dsl.js
@@ -93,13 +93,12 @@ Pact.MockService = Pact.MockService || {};
 
 (function() {
 
-  var _baseURL = 'http://127.0.0.1:';
-
+  var _baseURL;
   this.interactions = [];
   this.pactDetails = {};
 
   this.init = function(opts) {
-    _baseURL += opts.port;
+    _baseURL = 'http://127.0.0.1:' + opts.port;
 
     this.pactDetails = {
       consumer: {

--- a/spec/mock_service_spec.js
+++ b/spec/mock_service_spec.js
@@ -4,7 +4,7 @@ describe('MockService', function() {
     mockService;
 
   beforeEach(function() {
-    mockService = mockService ? mockService : Pact.mockService({
+    mockService = Pact.mockService({
       consumerName: 'Consumer',
       providerName: 'Provider',
       port: 1234,

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -4,13 +4,12 @@ Pact.MockService = Pact.MockService || {};
 
 (function() {
 
-  var _baseURL = 'http://127.0.0.1:';
-
+  var _baseURL;
   this.interactions = [];
   this.pactDetails = {};
 
   this.init = function(opts) {
-    _baseURL += opts.port;
+    _baseURL = 'http://127.0.0.1:' + opts.port;
 
     this.pactDetails = {
       consumer: {


### PR DESCRIPTION
I thought about introducing an immutable internal object to represent the current state of MockService but decided that was too complex, and instead opted for a simple fix. Tests are updated and green.

I still think this object needs some work however, as it continues to have unexpected behaviour due to shared state. For example:

```
var mock1 = Pact.mockService({consumerName: 'client', port: 1234, providerName: 'server', pactDir: 'spec/pacts'});
mock1.write(); //makes request to localhost:1234
var mock2 = Pact.mockService({consumerName: 'client', port: 4321, providerName: 'server', pactDir: 'spec/pacts'});
mock2.write(); //makes request to localhost:4321
mock1.write(); //makes request to localhost:4321 - this is unexpected
```
