### PR TITLE
Fix use of XHR status in DSL code

### DIFF
--- a/dist/pact-js-dsl.js
+++ b/dist/pact-js-dsl.js
@@ -89,6 +89,8 @@ Pact.Interaction = Pact.Interaction || {};
 
 'use strict';
 
+if (!XMLHttpRequest) { var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest; }
+
 Pact.MockService = Pact.MockService || {};
 
 (function() {
@@ -186,3 +188,5 @@ Pact.MockService = Pact.MockService || {};
   };
 
 }).apply(Pact.MockService);
+
+module.exports = Pact;

--- a/dist/pact-js-dsl.js
+++ b/dist/pact-js-dsl.js
@@ -124,7 +124,7 @@ Pact.MockService = Pact.MockService || {};
 
     this.clean = function() {
       var xhr = this.request('DELETE', _baseURL + '/interactions', null);
-      if (200 !== xhr.status) {
+      if (200 !== parseInt(xhr.status)) {
         throw 'pact-js-dsl: Pact cleanup failed. ' + xhr.responseText;
       }
     };
@@ -136,7 +136,7 @@ Pact.MockService = Pact.MockService || {};
 
       interactions.forEach(function(interaction) {
         var xhr = self.request('POST', _baseURL + '/interactions', JSON.stringify(interaction));
-        if (200 !== xhr.status) {
+        if (200 !== parseInt(xhr.status)) {
           throw 'pact-js-dsl: Pact interaction setup failed. ' + xhr.responseText;
         }
       });
@@ -144,14 +144,14 @@ Pact.MockService = Pact.MockService || {};
 
     this.verify = function() {
       var xhr = this.request('GET', _baseURL + '/interactions/verification', null);
-      if (200 !== xhr.status) {
+      if (200 !== parseInt(xhr.status)) {
         throw 'pact-js-dsl: Pact verification failed. ' + xhr.responseText;
       }
     };
 
     this.write = function() {
       var xhr = this.request('POST', _baseURL + '/pact', JSON.stringify(_pactDetails));
-      if (200 !== xhr.status) {
+      if (200 !== parseInt(xhr.status)) {
         throw 'pact-js-dsl: Could not write the pact file. ' + xhr.responseText;
       }
     };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ gulp.task('clean', ['clear'], function() {
 });
 
 gulp.task('build', ['clean'], function() {
-  return gulp.src(['src/pact.js', 'src/interaction.js', 'src/mockService.js'])
+  return gulp.src(['src/pact.js', 'src/interaction.js', 'src/mockService.js', 'src/exports.js'])
     .pipe($.jshint())
     .pipe($.jshint.reporter(require('jshint-checkstyle-file-reporter')))
     .pipe($.concat('pact-js-dsl.js'))

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "pact-js-dsl",
   "version": "0.0.1",
   "description": "DSL to write pact tests in Javascript",
-  "main": "gulpfile.js",
-  "dependencies": {},
+  "main": "dist/pact-js-dsl.js",
+  "dependencies": {
+    "xmlhttprequest": "^1.6.0"
+  },
   "devDependencies": {
     "gulp": "^3.6.0",
     "gulp-cache": "^0.1.1",
@@ -16,20 +18,28 @@
     "jshint-checkstyle-file-reporter": "0.0.1",
     "jshint-stylish": "^0.2.0",
     "karma": "0.12.24",
-    "karma-jasmine": "^0.1.5",
     "karma-chrome-launcher": "0.1.2",
     "karma-firefox-launcher": "^0.1.3",
+    "karma-jasmine": "^0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-safari-launcher": "~0.1"
   },
-  "contributors": [{
-    "name": "Fu Ying",
-    "email": "fu.ying.er@rea-group.com"
-  }, {
-    "name": "Malinda Kapuruge",
-    "email": "mkapuruge@dius.com.au"
-  }, {
-    "name": "Tarcio Saraiva",
-    "email": "tsaraiva@dius.com.au"
-  }]
+  "contributors": [
+    {
+      "name": "Fu Ying",
+      "email": "fu.ying.er@rea-group.com"
+    },
+    {
+      "name": "Malinda Kapuruge",
+      "email": "mkapuruge@dius.com.au"
+    },
+    {
+      "name": "Tarcio Saraiva",
+      "email": "tsaraiva@dius.com.au"
+    },
+    {
+      "name": "Tal Rotbart",
+      "email": "redbeard@gmail.com"
+    }
+  ]
 }

--- a/src/exports.js
+++ b/src/exports.js
@@ -1,0 +1,1 @@
+module.exports = Pact;

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -35,7 +35,7 @@ Pact.MockService = Pact.MockService || {};
 
     this.clean = function() {
       var xhr = this.request('DELETE', _baseURL + '/interactions', null);
-      if (200 !== xhr.status) {
+      if (200 !== parseInt(xhr.status)) {
         throw 'pact-js-dsl: Pact cleanup failed. ' + xhr.responseText;
       }
     };
@@ -47,7 +47,7 @@ Pact.MockService = Pact.MockService || {};
 
       interactions.forEach(function(interaction) {
         var xhr = self.request('POST', _baseURL + '/interactions', JSON.stringify(interaction));
-        if (200 !== xhr.status) {
+        if (200 !== parseInt(xhr.status)) {
           throw 'pact-js-dsl: Pact interaction setup failed. ' + xhr.responseText;
         }
       });
@@ -55,14 +55,14 @@ Pact.MockService = Pact.MockService || {};
 
     this.verify = function() {
       var xhr = this.request('GET', _baseURL + '/interactions/verification', null);
-      if (200 !== xhr.status) {
+      if (200 !== parseInt(xhr.status)) {
         throw 'pact-js-dsl: Pact verification failed. ' + xhr.responseText;
       }
     };
 
     this.write = function() {
       var xhr = this.request('POST', _baseURL + '/pact', JSON.stringify(_pactDetails));
-      if (200 !== xhr.status) {
+      if (200 !== parseInt(xhr.status)) {
         throw 'pact-js-dsl: Could not write the pact file. ' + xhr.responseText;
       }
     };

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -1,5 +1,7 @@
 'use strict';
 
+if (!XMLHttpRequest) { var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest; }
+
 Pact.MockService = Pact.MockService || {};
 
 (function() {


### PR DESCRIPTION
In the node based XMLHTTPRequest object, xhr.status is a string not an int; Fixing code to account for both browser and node.