### PR TITLE
Add nodejs support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,7 @@
   "quotmark": "single",
   "undef": true,
   "unused": true,
-  "strict": true,
+  "strict": false,
   "trailing": true,
   "smarttabs": true,
   "jquery": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,19 @@ You need to install grunt-cli, bower and karma first
 
 Inside the project folder, simply run `npm install` and `bundle install` to install the other dependencies.
 
-### Running tests
+### During Development
 
-    $ gulp run-tests
+To run gulp tasks:
 
-or
+    $ gulp
+
+or if you don't want to install the gulp-cli globally:
 
     $ node_modules/.bin/gulp run-tests
+
+Useful gulp tasks:
+- `gulp run-tests` will build the distribution file, spin up the pact server and run the tests in a browser and in nodejs.
+- `gulp watch` will spin up the pact server and automatically rerun the tests in a browser every time a relevant file is changed.
 
 ### Run example test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,9 @@ Useful gulp tasks:
 ### Run example test
 
     $ cd example
-    $ script/setup.sh
-    $ script/test.sh
+    $ bundle install
+    $ npm install
+    $ npm test
 
 ### Create the pact-consumer-js-dsl.js
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ This DSL relies on the Ruby [pact-mock_service][pact-mock-service] gem to provid
         helloProvider = MockService.create({
           consumer: 'Hello Consumer',
           provider: 'Hello Provider',
-          port: 1234
+          port: 1234,
+          done: function (error) {
+            expect(error).toBe(null);
+          }
         });
       });
 
@@ -87,12 +90,7 @@ This DSL relies on the Ruby [pact-mock_service][pact-mock-service] gem to provid
             reply: "Hello"
           });
 
-        helloProvider.done(function(pactError) {
-          expect(pactError).toBe(null);
-          done();
-        });
-
-        helloProvider.run(function(runComplete) {
+        helloProvider.run(done, function(runComplete) {
           expect(client.sayHello()).toEqual("Hello");
           runComplete();
         });

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ This DSL relies on the Ruby [pact-mock_service][pact-mock-service] gem to provid
 Have a look at the [example](/example) folder. Ensure you have Google Chrome installed.
 
     $ cd example
+    $ bundle install
     $ npm install
-    $ script/test.sh
+    $ npm test
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This DSL relies on the Ruby [pact-mock_service][pact-mock-service] gem to provid
 
 1. Write a Jasmine unit test similar to the following,
 
-        describe("Client", function(done) {
+        describe("Client", function() {
 
             var client, helloProvider;
 
@@ -77,7 +77,7 @@ This DSL relies on the Ruby [pact-mock_service][pact-mock-service] gem to provid
                 port: 1234 });
             });
 
-            it("should say hello", function() {
+            it("should say hello", function(done) {
 
                 helloProvider
                   .uponReceiving("a request for hello")
@@ -90,7 +90,10 @@ This DSL relies on the Ruby [pact-mock_service][pact-mock-service] gem to provid
 
                   helloProvider.run(function(runComplete) {
                     expect(client.sayHello()).toEqual("Hello");
-                    runComplete(done);
+                    runComplete(function (pactError) {
+                        expect(pactError).toBe(null);
+                        done();
+                    });
                   });
             });
          });

--- a/README.md
+++ b/README.md
@@ -64,41 +64,43 @@ This DSL relies on the Ruby [pact-mock_service][pact-mock-service] gem to provid
 
 1. Write a Jasmine unit test similar to the following,
 
-        describe("Client", function() {
+    ```
+    describe("Client", function() {
+      var client, helloProvider;
 
-            var client, helloProvider;
+      beforeEach(function() {
+        client = new ProviderClient('http://localhost:1234');
+        helloProvider = MockService.create({
+          consumer: 'Hello Consumer',
+          provider: 'Hello Provider',
+          port: 1234
+        });
+      });
 
-            beforeEach(function() {
+      it("should say hello", function(done) {
+        helloProvider
+          .uponReceiving("a request for hello")
+          .withRequest("get", "/sayHello")
+          .willRespondWith(200, {
+            "Content-Type": "application/json"
+          }, {
+            reply: "Hello"
+          });
 
-              client = new ProviderClient('http://localhost:1234');
-              helloProvider = MockService.create({
-                consumer: 'Hello Consumer',
-                provider: 'Hello Provider',
-                port: 1234 });
-            });
+        helloProvider.done(function(pactError) {
+          expect(pactError).toBe(null);
+          done();
+        });
 
-            it("should say hello", function(done) {
+        helloProvider.run(function(runComplete) {
+          expect(client.sayHello()).toEqual("Hello");
+          runComplete();
+        });
+      });
+    });
+    ```
 
-                helloProvider
-                  .uponReceiving("a request for hello")
-                  .withRequest("get", "/sayHello")
-                  .willRespondWith(200, {
-                    "Content-Type": "application/json"
-                  }, {
-                    reply: "Hello"
-                  });
-
-                  helloProvider.run(function(runComplete) {
-                    expect(client.sayHello()).toEqual("Hello");
-                    runComplete(function (pactError) {
-                        expect(pactError).toBe(null);
-                        done();
-                    });
-                  });
-            });
-         });
-
-    See the spec in the example directory for examples of asynchronous callbacks, how to expect error responses, and how to use query params.
+    See the spec in the example directory for more examples of asynchronous callbacks, how to expect error responses, and how to use query params.
 
     Make sure the source and test files are included by Karma in the `karma.conf.js` in the files array.
 

--- a/dist/pact-consumer-js-dsl.js
+++ b/dist/pact-consumer-js-dsl.js
@@ -207,11 +207,7 @@ Pact.MockService = Pact.MockService || {};
 
   function MockService(opts) {
     var _baseURL = 'http://127.0.0.1:' + opts.port;
-    var _doneCallback = function(error) {
-      if (error) {
-        throw error;
-      }
-    };
+    var _doneCallback = opts.done;
     var _interactions = [];
 
     var _pactDetails = {
@@ -279,23 +275,24 @@ Pact.MockService = Pact.MockService || {};
       return interaction;
     };
 
-    this.run = function(testFunction) {
+    this.run = function(onRunComplete, testFunction) {
+      var done = function (error) {
+        _doneCallback(error);
+        onRunComplete();
+      };
+
       cleanAndSetup(function(error) {
         if (error) {
-          _doneCallback(error);
+          done(error);
           return;
         }
 
         var runComplete = function() {
-          verifyAndWrite(_doneCallback);
+          verifyAndWrite(done);
         };
 
         testFunction(runComplete); // Call the tests
       });
-    };
-
-    this.done = function(callback) {
-      _doneCallback = callback;
     };
   }
 

--- a/dist/pact-consumer-js-dsl.js
+++ b/dist/pact-consumer-js-dsl.js
@@ -207,6 +207,11 @@ Pact.MockService = Pact.MockService || {};
 
   function MockService(opts) {
     var _baseURL = 'http://127.0.0.1:' + opts.port;
+    var _doneCallback = function(error) {
+      if (error) {
+        throw error;
+      }
+    };
     var _interactions = [];
 
     var _pactDetails = {
@@ -262,12 +267,6 @@ Pact.MockService = Pact.MockService || {};
       });
     };
 
-    var throwOnError = function(error) {
-      if (error) {
-        throw error;
-      }
-    };
-
     this.given = function(providerState) {
       var interaction = Pact.givenInteraction(providerState);
       _interactions.push(interaction);
@@ -283,16 +282,20 @@ Pact.MockService = Pact.MockService || {};
     this.run = function(testFunction) {
       cleanAndSetup(function(error) {
         if (error) {
-          throw error;
+          _doneCallback(error);
+          return;
         }
 
-        var runComplete = function(testComplete) {
-          testComplete = (typeof testComplete === 'function') ? testComplete : throwOnError;
-          verifyAndWrite(testComplete);
+        var runComplete = function() {
+          verifyAndWrite(_doneCallback);
         };
 
         testFunction(runComplete); // Call the tests
       });
+    };
+
+    this.done = function(callback) {
+      _doneCallback = callback;
     };
   }
 

--- a/example/client-spec.js
+++ b/example/client-spec.js
@@ -2,11 +2,11 @@
 
   describe("Client", function() {
 
-    var client, helloProvider, withNoError;
+    var client, expectNoErrors, helloProvider;
 
-    withNoError = function (doneCallback) {
-      return function (error) {
-        expect(error).toBe(null);
+    expectNoErrors = function (doneCallback) {
+      return function (pactError) {
+        expect(pactError).toBe(null);
         doneCallback();
       };
     };
@@ -33,10 +33,12 @@
             reply: "Hello"
           });
 
+        helloProvider.done(expectNoErrors(done));
+
         //Run the tests
         helloProvider.run(function(runComplete) {
           expect(client.sayHello()).toEqual("Hello");
-          runComplete(withNoError(done));
+          runComplete();
         });
 
       });
@@ -70,12 +72,14 @@
             }
           });
 
+        helloProvider.done(expectNoErrors(done));
+
         //Run the tests
         helloProvider.run(function(runComplete) {
           expect(client.findFriendsByAgeAndChildren('30', ['Mary Jane', 'James'])).toEqual([{
             name: 'Sue'
           }]);
-          runComplete(withNoError(done));
+          runComplete();
         });
 
       });
@@ -100,17 +104,18 @@
             }
           });
 
+        helloProvider.done(expectNoErrors(done));
 
         //Run the tests
         helloProvider.run(function(runComplete) {
 
           function success(message) {
             expect(message).toEqual("Bye");
-            runComplete(withNoError(done));
+            runComplete();
           }
 
           function error(response) {
-            runComplete(withNoError(done));
+            runComplete();
             expect(true).toEqual(false);
           }
 
@@ -128,19 +133,21 @@
             .withRequest("put", "/unfriendMe")
             .willRespondWith(404);
 
+          helloProvider.done(expectNoErrors(done));
+
           //Run the tests
           helloProvider.run(function(runComplete) {
 
             function success(message) {
               //The success callback should *not* be invoked!
               expect(true).toEqual(false);
-              runComplete(withNoError(done));
+              runComplete();
             }
 
             function error(message) {
               //The error callback *should* be invoked
               expect(message).toEqual("No friends :(");
-              runComplete(withNoError(done));
+              runComplete();
             }
 
             client.unfriendMe(success, error);

--- a/example/client-spec.js
+++ b/example/client-spec.js
@@ -2,14 +2,7 @@
 
   describe("Client", function() {
 
-    var client, expectNoErrors, helloProvider;
-
-    expectNoErrors = function (doneCallback) {
-      return function (pactError) {
-        expect(pactError).toBe(null);
-        doneCallback();
-      };
-    };
+    var client, helloProvider;
 
     // ugly but works... guess would be good to bring jasmine-beforeAll
     beforeEach(function() {
@@ -17,7 +10,10 @@
       helloProvider = Pact.mockService({
         consumer: 'Hello Consumer',
         provider: 'Hello Provider',
-        port: 1234
+        port: 1234,
+        done: function (error) {
+          expect(error).toBe(null);
+        }
       });
     });
 
@@ -33,10 +29,8 @@
             reply: "Hello"
           });
 
-        helloProvider.done(expectNoErrors(done));
-
         //Run the tests
-        helloProvider.run(function(runComplete) {
+        helloProvider.run(done, function(runComplete) {
           expect(client.sayHello()).toEqual("Hello");
           runComplete();
         });
@@ -72,10 +66,8 @@
             }
           });
 
-        helloProvider.done(expectNoErrors(done));
-
         //Run the tests
-        helloProvider.run(function(runComplete) {
+        helloProvider.run(done, function(runComplete) {
           expect(client.findFriendsByAgeAndChildren('30', ['Mary Jane', 'James'])).toEqual([{
             name: 'Sue'
           }]);
@@ -104,10 +96,8 @@
             }
           });
 
-        helloProvider.done(expectNoErrors(done));
-
         //Run the tests
-        helloProvider.run(function(runComplete) {
+        helloProvider.run(done, function(runComplete) {
 
           function success(message) {
             expect(message).toEqual("Bye");
@@ -133,10 +123,8 @@
             .withRequest("put", "/unfriendMe")
             .willRespondWith(404);
 
-          helloProvider.done(expectNoErrors(done));
-
           //Run the tests
-          helloProvider.run(function(runComplete) {
+          helloProvider.run(done, function(runComplete) {
 
             function success(message) {
               //The success callback should *not* be invoked!

--- a/example/client-spec.js
+++ b/example/client-spec.js
@@ -2,7 +2,14 @@
 
   describe("Client", function() {
 
-    var client, helloProvider;
+    var client, helloProvider, withNoError;
+
+    withNoError = function (doneCallback) {
+      return function (error) {
+        expect(error).toBe(null);
+        doneCallback();
+      };
+    };
 
     // ugly but works... guess would be good to bring jasmine-beforeAll
     beforeEach(function() {
@@ -15,7 +22,7 @@
     });
 
     describe("sayHello", function () {
-      it("should say hello", function() {
+      it("should say hello", function(done) {
 
         helloProvider
           .uponReceiving("a request for hello")
@@ -27,16 +34,16 @@
           });
 
         //Run the tests
-        helloProvider.run(function(complete) {
+        helloProvider.run(function(runComplete) {
           expect(client.sayHello()).toEqual("Hello");
-          complete();
+          runComplete(withNoError(done));
         });
 
       });
     });
 
     describe("findFriendsByAgeAndChildren", function () {
-      it("should return some friends", function() {
+      it("should return some friends", function(done) {
         //Add interaction
         helloProvider
           .uponReceiving("a request friends")
@@ -64,11 +71,11 @@
           });
 
         //Run the tests
-        helloProvider.run(function(complete) {
+        helloProvider.run(function(runComplete) {
           expect(client.findFriendsByAgeAndChildren('30', ['Mary Jane', 'James'])).toEqual([{
             name: 'Sue'
           }]);
-          complete();
+          runComplete(withNoError(done));
         });
 
       });
@@ -77,7 +84,7 @@
 
     describe("unfriendMe", function () {
 
-      it("should unfriend me", function(jasmineDone) {
+      it("should unfriend me", function(done) {
         //Add interaction
         helloProvider
           .given("I am friends with Fred")
@@ -95,15 +102,15 @@
 
 
         //Run the tests
-        helloProvider.run(function(pactDone) {
+        helloProvider.run(function(runComplete) {
 
           function success(message) {
             expect(message).toEqual("Bye");
-            pactDone(jasmineDone);
+            runComplete(withNoError(done));
           }
 
           function error(response) {
-            pactDone(jasmineDone);
+            runComplete(withNoError(done));
             expect(true).toEqual(false);
           }
 
@@ -113,7 +120,7 @@
       });
 
       describe("when there are no friends", function () {
-        it("returns an error message", function (jasmineDone) {
+        it("returns an error message", function (done) {
           //Add interaction
           helloProvider
             .given("I have no friends")
@@ -122,18 +129,18 @@
             .willRespondWith(404);
 
           //Run the tests
-          helloProvider.run(function(pactDone) {
+          helloProvider.run(function(runComplete) {
 
             function success(message) {
               //The success callback should *not* be invoked!
               expect(true).toEqual(false);
-              pactDone(jasmineDone);
+              runComplete(withNoError(done));
             }
 
             function error(message) {
               //The error callback *should* be invoked
-              expect(message).toEqual("No friends :(")
-              pactDone(jasmineDone);
+              expect(message).toEqual("No friends :(");
+              runComplete(withNoError(done));
             }
 
             client.unfriendMe(success, error);

--- a/example/karma.conf.js
+++ b/example/karma.conf.js
@@ -15,11 +15,11 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      // if you are using this example to setup your own project load pact from the node_modules directory
+      // i.e. node_modules/pact-consumer-js-dsl/dist/pact-consumer-js-dsl.js
+      '../dist/pact-consumer-js-dsl.js',
       'client.js',
-      'client-spec.js',
-      '../src/pact.js',
-      '../src/interaction.js',
-      '../src/mockService.js',
+      'client-spec.js'
     ],
 
     // list of files to exclude

--- a/example/package.json
+++ b/example/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "pact-js",
+  "name": "pact-consumer-js-dsl-example",
   "version": "1.0.0",
   "scripts": {
-    "test": "karma start"
+    "test": "script/test.sh"
   },
   "devDependencies": {
     "karma": "^0.12.24",

--- a/example/script/setup.sh
+++ b/example/script/setup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-npm install

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,47 +1,115 @@
 'use strict';
 
 var gulp = require('gulp'),
-  fs = require('fs'),
+  fs = require('fs-extra'),
+  q = require('q'),
+  request = require('request'),
   spawn = require('child_process').spawn,
-  karma = require('karma').server,
   $ = require('gulp-load-plugins')();
+
+var cleanDirectories = function(directories) {
+  directories.forEach(function(directory) {
+    fs.removeSync(directory);
+    fs.mkdirsSync(directory);
+  });
+};
+
+var waitForServerToStart = function () {
+  var deferred = q.defer();
+  var attempts = 0;
+
+  var checkIfServerHasStarted = function () {
+    attempts += 1;
+    request('http://localhost:1234', function (error) {
+      if (attempts > 100) {
+        deferred.reject(new Error('Timed out waiting for the pact-mock-service to start'));
+      } else if (error) {
+        setTimeout(checkIfServerHasStarted, 100);
+      } else {
+        deferred.resolve();
+      }
+    });
+  };
+
+  checkIfServerHasStarted();
+
+  return deferred.promise;
+};
+
+var withServer = function(action) {
+  var deferred = q.defer();
+
+  cleanDirectories(['tmp/pacts', 'log']);
+  var child = spawn('bundle', ['exec', 'pact-mock-service', '-p', '1234', '-l', 'tmp/pact.log', '--pact-dir', './tmp/pacts']);
+  child.on('error', function(error) {
+    console.log('pact-mock-service:', error.toString());
+  });
+
+  waitForServerToStart().then(function () {
+    var actionDone = function(error) {
+      child.kill();
+
+      if (error) {
+        deferred.reject(error);
+      } else {
+        deferred.resolve();
+      }
+    };
+
+    var actionStream = action();
+    actionStream.on('end', actionDone);
+    actionStream.on('error', actionDone);
+    actionStream.resume();
+  });
+
+  return deferred.promise;
+};
+
+var srcFiles = ['src/bootstrap.js', 'src/pact.js', 'src/interaction.js', 'src/http.js', 'src/mockServiceRequests.js', 'src/mockService.js'];
+var specFiles = ['spec/**/*spec.js'];
+var distFiles = ['dist/pact-consumer-js-dsl.js'];
+var karmaConfig = 'spec/karma.conf.js';
 
 gulp.task('clear', function(done) {
   return $.cache.clearAll(done);
 });
 
 gulp.task('clean', ['clear'], function() {
-  return gulp.src(['tmp', 'dist', 'log'], {
+  return gulp.src(['dist'], {
     read: false
   }).pipe($.clean());
 });
 
 gulp.task('build', ['clean'], function() {
-  return gulp.src(['src/pact.js', 'src/interaction.js', 'src/mockServiceRequests.js', 'src/mockService.js'])
+  return gulp.src(srcFiles)
     .pipe($.jshint())
-    .pipe($.jshint.reporter(require('jshint-checkstyle-file-reporter')))
+    .pipe($.jshint.reporter('default'))
     .pipe($.concat('pact-consumer-js-dsl.js'))
     .pipe(gulp.dest('dist'))
     .pipe($.size());
 });
 
-gulp.task('default', ['build']);
-
-gulp.task('run-tests', ['build'], function() {
-  var karmaConf = process.argv[3] ? process.argv[3] : 'karma';
-
-  fs.mkdirSync('tmp');
-  fs.mkdirSync('tmp/pacts');
-  fs.mkdirSync('log');
-
-  var child = spawn('bundle', ['exec', 'pact-mock-service', '-p', '1234', '-l', 'tmp/pact.log', '--pact-dir', './tmp/pacts']);
-
-  karma.start({
-    configFile: __dirname + '/spec/' + karmaConf + '.conf.js',
-    singleRun: true
-  }, function(code) {
-    process.kill(child.pid, 'SIGKILL');
-    process.exit(code);
+gulp.task('run-browser-tests', ['build'], function() {
+  return withServer(function() {
+    return gulp.src(distFiles.concat(specFiles))
+      .pipe($.karma({configFile: karmaConfig}));
   });
-
 });
+
+gulp.task('run-node-tests', ['build', 'run-browser-tests'], function() {
+  return withServer(function() {
+    return gulp.src(distFiles.concat(specFiles))
+      .pipe($.jasmine());
+  });
+});
+
+gulp.task('run-tests', ['run-browser-tests', 'run-node-tests']);
+
+gulp.task('watch', ['clean'], function() {
+  return withServer(function() {
+    return gulp.src(srcFiles.concat(specFiles))
+      .pipe($.karma({configFile: 'spec/karma.conf.js', action: 'watch'}));
+  });
+});
+
+gulp.task('default', ['build']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ gulp.task('clean', ['clear'], function() {
 });
 
 gulp.task('build', ['clean'], function() {
-  return gulp.src(['src/pact.js', 'src/interaction.js', 'src/mockService.js'])
+  return gulp.src(['src/pact.js', 'src/interaction.js', 'src/mockServiceRequests.js', 'src/mockService.js'])
     .pipe($.jshint())
     .pipe($.jshint.reporter(require('jshint-checkstyle-file-reporter')))
     .pipe($.concat('pact-consumer-js-dsl.js'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ var waitForServerToStart = function () {
     });
   };
 
-  checkIfServerHasStarted();
+  setTimeout(checkIfServerHasStarted, 1000);
 
   return deferred.promise;
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@ var withServer = function(action) {
     actionStream.on('end', actionDone);
     actionStream.on('error', actionDone);
     actionStream.resume();
-  });
+  }, deferred.reject);
 
   return deferred.promise;
 };

--- a/package.json
+++ b/package.json
@@ -6,28 +6,33 @@
   "dependencies": {},
   "browserDependencies": {},
   "devDependencies": {
+    "fs-extra": "^0.13.0",
     "gulp": "^3.6.0",
     "gulp-cache": "^0.1.1",
     "gulp-clean": "^0.2.4",
     "gulp-concat": "^2.4.2",
+    "gulp-jasmine": "^1.0.1",
     "gulp-jshint": "^1.5.3",
+    "gulp-karma": "0.0.4",
     "gulp-load-plugins": "^0.5.0",
     "gulp-size": "^0.3.0",
     "gulp-uglify": "^0.2.1",
-    "jshint-checkstyle-file-reporter": "0.0.1",
     "jshint-stylish": "^0.2.0",
     "karma": "0.12.24",
-    "karma-jasmine": "^0.2.0",
     "karma-chrome-launcher": "0.1.2",
     "karma-firefox-launcher": "^0.1.3",
+    "karma-jasmine": "^0.2.0",
     "karma-phantomjs-launcher": "^0.1.4",
-    "karma-safari-launcher": "~0.1"
+    "karma-safari-launcher": "~0.1",
+    "q": "^1.1.2",
+    "request": "^2.51.0"
   },
   "contributors": [
     "Fu Ying <fu.ying.er@rea-group.com>",
     "Malinda Kapuruge <mkapuruge@dius.com.au>",
     "Tarcio Saraiva <tsaraiva@dius.com.au>",
-    "Beth Skurrie <bskurrie@dius.com.au>"
+    "Beth Skurrie <bskurrie@dius.com.au>",
+    "Ben Sayers <bpsayers@gmail.com>"
   ],
   "directories": {
     "lib": "src",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pact-consumer-js-dsl",
   "version": "0.0.4",
   "description": "DSL to write pact tests in Javascript",
-  "main": "gulpfile.js",
+  "main": "dist/pact-consumer-js-dsl.js",
   "dependencies": {},
   "browserDependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jshint-checkstyle-file-reporter": "0.0.1",
     "jshint-stylish": "^0.2.0",
     "karma": "0.12.24",
-    "karma-jasmine": "^0.1.5",
+    "karma-jasmine": "^0.2.0",
     "karma-chrome-launcher": "0.1.2",
     "karma-firefox-launcher": "^0.1.3",
     "karma-phantomjs-launcher": "^0.1.4",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(config) {
     files: [
       'src/pact.js',
       'src/interaction.js',
+      'src/mockServiceRequests.js',
       'src/mockService.js',
       'spec/**/*spec.js'
     ],

--- a/spec/mock_service_spec.js
+++ b/spec/mock_service_spec.js
@@ -1,11 +1,17 @@
 'use strict';
 
 describe('MockService', function() {
-  var baseUrl, isNodeJs, mockService, Pact;
+  var baseUrl, isNodeJs, mockService, Pact, withNoError;
 
   baseUrl = 'http://localhost:1234';
   isNodeJs = typeof module === 'object' && typeof module.exports === 'object';
   Pact = (isNodeJs) ? require('../dist/pact-consumer-js-dsl.js') : window.Pact;
+  withNoError = function (doneCallback) {
+    return function (error) {
+      expect(error).toBe(null);
+      doneCallback();
+    };
+  };
 
   var makeRequestForNode = function (options, callback) {
     var request = require('request');
@@ -90,7 +96,7 @@ describe('MockService', function() {
           expect(JSON.parse(response.responseText)).toEqual({reply: 'Hello'}, 'responseText');
           expect(response.status).toEqual(201, 'status');
           expect(response.getResponseHeader('Content-Type')).toEqual('application/json', 'Content-Type header');
-          runComplete(done);
+          runComplete(withNoError(done));
         });
       });
 
@@ -138,7 +144,7 @@ describe('MockService', function() {
           expect(JSON.parse(response.responseText)).toEqual({reply: 'Hello'}, 'responseText');
           expect(response.status).toEqual(201, 'status');
           expect(response.getResponseHeader('Content-Type')).toEqual('application/json', 'Content-Type header');
-          runComplete(done);
+          runComplete(withNoError(done));
         });
       });
 
@@ -171,7 +177,7 @@ describe('MockService', function() {
         doHttpCall(function (error, response) {
           expect(error).toBe(null, 'error');
           expect(response.status).toEqual(201, 'status');
-          runComplete(done);
+          runComplete(withNoError(done));
         });
       });
     });
@@ -213,7 +219,7 @@ describe('MockService', function() {
             expect(differentResponseError).toBe(null, 'differentResponseError');
             expect(response.responseText).toEqual('thing response', 'response.responseText');
             expect(differentResponse.responseText).toEqual('different thing response', 'differentResponse.responseText');
-            runComplete(done);
+            runComplete(withNoError(done));
           });
         });
       });
@@ -239,7 +245,7 @@ describe('MockService', function() {
         doHttpCall(function (error, response) {
           expect(error).toBe(null, 'error');
           expect(response.status).toEqual(201, 'status');
-          runComplete(done);
+          runComplete(withNoError(done));
         });
       });
     });

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var Pact = Pact || {};
+Pact.IsNodeJs = typeof module === 'object' && typeof module.exports === 'object';
+
+if (Pact.IsNodeJs) {
+  module.exports = Pact;
+}

--- a/src/http.js
+++ b/src/http.js
@@ -1,0 +1,59 @@
+Pact.Http = Pact.Http || {};
+
+(function() {
+  var makeRequestForNode = function(method, url, body, callback) {
+    var http = require('http');
+    var parse = require('url').parse;
+
+    var parsedUrl = parse(url);
+    var requestOptions = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port,
+      method: method,
+      path: parsedUrl.path,
+      headers: {
+        'X-Pact-Mock-Service': 'true',
+        'Content-Type': 'application/json'
+      }
+    };
+
+    var request = http.request(requestOptions, function (response) {
+      var responseText = '';
+
+      response.on('data', function (chunk) {
+        responseText += chunk.toString();
+      });
+
+      response.on('error', function (err) {
+        callback(new Error('Error calling ' + url + ' - ' + err.message));
+      });
+
+      response.on('end', function () {
+        callback(null, {responseText: responseText, status: response.statusCode});
+      });
+    });
+
+    request.on('error', function (err) {
+      callback(new Error('Error calling ' + url + ' - ' + err.message));
+    });
+
+    request.end(body || '');
+  };
+
+  var makeRequestForBrowser = function(method, url, body, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.onload = function(event) {
+      callback(null, event.target);
+    };
+    xhr.onerror = function() {
+      callback(new Error('Error calling ' + url));
+    };
+    xhr.open(method, url, true);
+    xhr.setRequestHeader('X-Pact-Mock-Service', 'true');
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.send(body);
+  };
+
+  this.makeRequest = (Pact.IsNodeJs) ? makeRequestForNode : makeRequestForBrowser;
+
+}).apply(Pact.Http);

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -1,5 +1,3 @@
-'use strict';
-
 Pact.Interaction = Pact.Interaction || {};
 
 (function() {

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -1,5 +1,3 @@
-'use strict';
-
 Pact.MockService = Pact.MockService || {};
 
 (function() {
@@ -18,25 +16,25 @@ Pact.MockService = Pact.MockService || {};
       }
     };
 
-    var setupInteractionsSequentially = function (interactions, index, callback) {
+    var setupInteractionsSequentially = function(interactions, index, callback) {
       if (index >= interactions.length) {
         callback();
         return;
       }
 
-      Pact.MockServiceRequests.postInteraction(interactions[index], _baseURL, function (error) {
+      Pact.MockServiceRequests.postInteraction(interactions[index], _baseURL, function(error) {
         if (error) {
           callback(error);
           return;
         }
 
-        setupInteractionsSequentially(interactions, index + 1, callback)
+        setupInteractionsSequentially(interactions, index + 1, callback);
       });
     };
 
-    var cleanAndSetup = function (callback) {
+    var cleanAndSetup = function(callback) {
       // Cleanup the interactions from the previous test
-      Pact.MockServiceRequests.deleteInteractions(_baseURL, function (deleteInteractionsError) {
+      Pact.MockServiceRequests.deleteInteractions(_baseURL, function(deleteInteractionsError) {
         if (deleteInteractionsError) {
           callback(deleteInteractionsError);
           return;
@@ -49,9 +47,9 @@ Pact.MockService = Pact.MockService || {};
       });
     };
 
-    var verifyAndWrite = function (callback) {
+    var verifyAndWrite = function(callback) {
       //Verify that the expected interactions have occurred
-      Pact.MockServiceRequests.getVerification(_baseURL, function (verifyError) {
+      Pact.MockServiceRequests.getVerification(_baseURL, function(verifyError) {
         if (verifyError) {
           callback(verifyError);
           return;
@@ -62,7 +60,7 @@ Pact.MockService = Pact.MockService || {};
       });
     };
 
-    var throwOnError = function (error) {
+    var throwOnError = function(error) {
       if (error) {
         throw error;
       }
@@ -81,7 +79,7 @@ Pact.MockService = Pact.MockService || {};
     };
 
     this.run = function(testFunction) {
-      cleanAndSetup(function (error) {
+      cleanAndSetup(function(error) {
         if (error) {
           throw error;
         }

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -5,11 +5,7 @@ Pact.MockService = Pact.MockService || {};
 
   function MockService(opts) {
     var _baseURL = 'http://127.0.0.1:' + opts.port;
-    var _doneCallback = function(error) {
-      if (error) {
-        throw error;
-      }
-    };
+    var _doneCallback = opts.done;
     var _interactions = [];
 
     var _pactDetails = {
@@ -77,23 +73,24 @@ Pact.MockService = Pact.MockService || {};
       return interaction;
     };
 
-    this.run = function(testFunction) {
+    this.run = function(onRunComplete, testFunction) {
+      var done = function (error) {
+        _doneCallback(error);
+        onRunComplete();
+      };
+
       cleanAndSetup(function(error) {
         if (error) {
-          _doneCallback(error);
+          done(error);
           return;
         }
 
         var runComplete = function() {
-          verifyAndWrite(_doneCallback);
+          verifyAndWrite(done);
         };
 
         testFunction(runComplete); // Call the tests
       });
-    };
-
-    this.done = function(callback) {
-      _doneCallback = callback;
     };
   }
 

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -5,6 +5,11 @@ Pact.MockService = Pact.MockService || {};
 
   function MockService(opts) {
     var _baseURL = 'http://127.0.0.1:' + opts.port;
+    var _doneCallback = function(error) {
+      if (error) {
+        throw error;
+      }
+    };
     var _interactions = [];
 
     var _pactDetails = {
@@ -60,12 +65,6 @@ Pact.MockService = Pact.MockService || {};
       });
     };
 
-    var throwOnError = function(error) {
-      if (error) {
-        throw error;
-      }
-    };
-
     this.given = function(providerState) {
       var interaction = Pact.givenInteraction(providerState);
       _interactions.push(interaction);
@@ -81,16 +80,20 @@ Pact.MockService = Pact.MockService || {};
     this.run = function(testFunction) {
       cleanAndSetup(function(error) {
         if (error) {
-          throw error;
+          _doneCallback(error);
+          return;
         }
 
-        var runComplete = function(testComplete) {
-          testComplete = (typeof testComplete === 'function') ? testComplete : throwOnError;
-          verifyAndWrite(testComplete);
+        var runComplete = function() {
+          verifyAndWrite(_doneCallback);
         };
 
         testFunction(runComplete); // Call the tests
       });
+    };
+
+    this.done = function(callback) {
+      _doneCallback = callback;
     };
   }
 

--- a/src/mockServiceRequests.js
+++ b/src/mockServiceRequests.js
@@ -1,0 +1,67 @@
+'use strict';
+
+Pact.MockServiceRequests = Pact.MockServiceRequests || {};
+
+(function() {
+  var request = function(method, url, body, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.onload = function(event) {
+      callback(null, event.target);
+    };
+    xhr.onerror = function() {
+      callback(new Error('Error calling ' + url));
+    };
+    xhr.open(method, url, true);
+    xhr.setRequestHeader('X-Pact-Mock-Service', 'true');
+    xhr.setRequestHeader('Content-type', 'application/json');
+    xhr.send(body);
+  };
+
+  this.getVerification = function(baseUrl, callback) {
+    request('GET', baseUrl + '/interactions/verification', null, function(error, xhr) {
+      if (error) {
+        callback(error);
+      } else if (200 !== xhr.status) {
+        callback(new Error('pact-js-dsl: Pact verification failed. ' + xhr.responseText));
+      } else {
+        callback(null);
+      }
+    });
+  };
+
+  this.deleteInteractions = function(baseUrl, callback) {
+    request('DELETE', baseUrl + '/interactions', null, function(error, xhr) {
+      if (error) {
+        callback(error);
+      } else if (200 !== xhr.status) {
+        callback(new Error('pact-js-dsl: Pact cleanup failed. ' + xhr.responseText));
+      } else {
+        callback(null);
+      }
+    });
+  };
+
+  this.postInteraction = function(interaction, baseUrl, callback) {
+    request('POST', baseUrl + '/interactions', JSON.stringify(interaction), function(error, xhr) {
+      if (error) {
+        callback(error);
+      } else if (200 !== xhr.status) {
+        callback(new Error('pact-js-dsl: Pact interaction setup failed. ' + xhr.responseText));
+      } else {
+        callback(null);
+      }
+    });
+  };
+
+  this.postPact = function(pactDetails, baseUrl, callback) {
+    request('POST', baseUrl + '/pact', JSON.stringify(pactDetails), function(error, xhr) {
+      if (error) {
+        callback(error);
+      } else if (200 !== xhr.status) {
+        throw 'pact-js-dsl: Could not write the pact file. ' + xhr.responseText;
+      } else {
+        callback(null);
+      }
+    });
+  };
+}).apply(Pact.MockServiceRequests);

--- a/src/mockServiceRequests.js
+++ b/src/mockServiceRequests.js
@@ -1,28 +1,12 @@
-'use strict';
-
 Pact.MockServiceRequests = Pact.MockServiceRequests || {};
 
 (function() {
-  var request = function(method, url, body, callback) {
-    var xhr = new XMLHttpRequest();
-    xhr.onload = function(event) {
-      callback(null, event.target);
-    };
-    xhr.onerror = function() {
-      callback(new Error('Error calling ' + url));
-    };
-    xhr.open(method, url, true);
-    xhr.setRequestHeader('X-Pact-Mock-Service', 'true');
-    xhr.setRequestHeader('Content-type', 'application/json');
-    xhr.send(body);
-  };
-
   this.getVerification = function(baseUrl, callback) {
-    request('GET', baseUrl + '/interactions/verification', null, function(error, xhr) {
+    Pact.Http.makeRequest('GET', baseUrl + '/interactions/verification', null, function(error, response) {
       if (error) {
         callback(error);
-      } else if (200 !== xhr.status) {
-        callback(new Error('pact-js-dsl: Pact verification failed. ' + xhr.responseText));
+      } else if (200 !== response.status) {
+        callback(new Error('pact-js-dsl: Pact verification failed. ' + response.responseText));
       } else {
         callback(null);
       }
@@ -30,11 +14,11 @@ Pact.MockServiceRequests = Pact.MockServiceRequests || {};
   };
 
   this.deleteInteractions = function(baseUrl, callback) {
-    request('DELETE', baseUrl + '/interactions', null, function(error, xhr) {
+    Pact.Http.makeRequest('DELETE', baseUrl + '/interactions', null, function(error, response) {
       if (error) {
         callback(error);
-      } else if (200 !== xhr.status) {
-        callback(new Error('pact-js-dsl: Pact cleanup failed. ' + xhr.responseText));
+      } else if (200 !== response.status) {
+        callback(new Error('pact-js-dsl: Pact cleanup failed. ' + response.responseText));
       } else {
         callback(null);
       }
@@ -42,11 +26,11 @@ Pact.MockServiceRequests = Pact.MockServiceRequests || {};
   };
 
   this.postInteraction = function(interaction, baseUrl, callback) {
-    request('POST', baseUrl + '/interactions', JSON.stringify(interaction), function(error, xhr) {
+    Pact.Http.makeRequest('POST', baseUrl + '/interactions', JSON.stringify(interaction), function(error, response) {
       if (error) {
         callback(error);
-      } else if (200 !== xhr.status) {
-        callback(new Error('pact-js-dsl: Pact interaction setup failed. ' + xhr.responseText));
+      } else if (200 !== response.status) {
+        callback(new Error('pact-js-dsl: Pact interaction setup failed. ' + response.responseText));
       } else {
         callback(null);
       }
@@ -54,11 +38,11 @@ Pact.MockServiceRequests = Pact.MockServiceRequests || {};
   };
 
   this.postPact = function(pactDetails, baseUrl, callback) {
-    request('POST', baseUrl + '/pact', JSON.stringify(pactDetails), function(error, xhr) {
+    Pact.Http.makeRequest('POST', baseUrl + '/pact', JSON.stringify(pactDetails), function(error, response) {
       if (error) {
         callback(error);
-      } else if (200 !== xhr.status) {
-        throw 'pact-js-dsl: Could not write the pact file. ' + xhr.responseText;
+      } else if (200 !== response.status) {
+        throw 'pact-js-dsl: Could not write the pact file. ' + response.responseText;
       } else {
         callback(null);
       }

--- a/src/pact.js
+++ b/src/pact.js
@@ -1,7 +1,3 @@
-'use strict';
-
-var Pact = Pact || {};
-
 (function() {
 
   // consumerName, providerName, port, pactDir


### PR DESCRIPTION
Summary of the changes I made:
- Added nodejs support
- Updated the tests to be compatible with nodejs. They are now run in a nodejs environment as well as a browser environment to ensure compatibility is maintained
- Updated mockService to make async http requests
- No longer expose internal mockService methods to external consumers to avoid confusion about what is api and what is not
- Refactored the low level http logic into mockServiceRequests and http
- Removed unnecessary 'use strict' statements - only 1 is needed at the top of the distribution file
- Added more robust pact server spin up code to the gulp file - the previous code did not wait for the server to spin up before running the tests which caused timing issues in nodejs which runs the tests faster then karma does

I've never used gulp before so I may not have done things in the "gulp" way. I also had a lot of merge conflicts when rebasing against master so please check I didn't blow away anything accidentally.