### PR TITLE
Updated the example to include the given() method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ gem 'pact-mock_service', '~> 0.4.1'
 
       it("should say hello", function(done) {
         helloProvider
+          .given("default server state")
           .uponReceiving("a request for hello")
           .withRequest("get", "/sayHello")
           .willRespondWith(200, {


### PR DESCRIPTION
As this is demanded by the (at least the jvm) provider so the `provider_state` will be set.