### PR TITLE
Unit tests for the MockService configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ log/
 example-*/log
 example-*/tmp
 checkstyle.xml
+
+.idea

--- a/dist/pact-consumer-js-dsl.js
+++ b/dist/pact-consumer-js-dsl.js
@@ -156,8 +156,13 @@ Pact.MockService = Pact.MockService || {};
 (function() {
 
   function MockService(opts) {
-    var host = opts.host || '127.0.0.1'
-    var _baseURL = 'http://' + host + ':' + opts.port;
+
+    if (!opts || typeof(opts.port) === 'undefined' ) {
+      throw new Error('Error creating MockService. Please provide the Pact mock service port');
+    }
+
+    var _host = opts.host || '127.0.0.1';
+    var _baseURL = 'http://' + _host + ':' + opts.port;
     var _interactions = [];
     var self = this;
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "example": "example"
   },
   "scripts": {
-    "test": "gulp run-tests"
+    "test": "gulp run-tests",
+    "unit-test": "gulp run-unit-tests"
   },
   "repository": {
     "type": "git",

--- a/spec/unit/mock_service_options_spec.js
+++ b/spec/unit/mock_service_options_spec.js
@@ -1,0 +1,83 @@
+'use strict';
+
+describe('mockService', function() {
+    var mockService;
+
+    describe('client configuration', function() {
+        beforeEach(function() {
+            spyOn(Pact.MockServiceRequests, 'putInteractions')
+                .and.callFake(function(interactions, baseUrl, callback) {});
+        });
+
+        describe('when provided a host option', function() {
+            beforeEach(function() {
+                mockService = Pact.mockService({
+                    consumer: 'Consumer',
+                    provider: 'Provider',
+                    port: 1234,
+                    done: function() {},
+                    host: '1.2.3.4'
+                });
+            });
+
+            it('should use the host option in pact mock service API request', function() {
+                mockService.setup(function() {});
+                expect(Pact.MockServiceRequests.putInteractions)
+                    .toHaveBeenCalledWith(jasmine.anything(), 'http://1.2.3.4:1234', jasmine.anything());
+            });
+        });
+
+        describe('when no host option is provided', function() {
+            beforeEach(function() {
+                mockService = Pact.mockService({
+                    consumer: 'Consumer',
+                    provider: 'Provider',
+                    port: 1234,
+                    done: function() {}
+                });
+            });
+
+            it('should use the default host in pact mock service API request', function() {
+                mockService.setup(function() {});
+
+                expect(Pact.MockServiceRequests.putInteractions)
+                    .toHaveBeenCalledWith(jasmine.anything(), 'http://127.0.0.1:1234', jasmine.anything());
+            });
+        });
+
+        describe('when no port is provided', function() {
+            it('should throw an error', function() {
+                var options = {
+                    consumer: 'Consumer',
+                    provider: 'Provider',
+                    done: function(){},
+                    host: '1.2.3.4'
+                };
+
+                var createMockService = function() {
+                    Pact.mockService(options)
+                };
+
+                expect(createMockService).toThrow();
+            });
+        });
+
+        describe('when a port is provided', function() {
+            it('should not throw an error', function() {
+                var options = {
+                    consumer: 'Consumer',
+                    provider: 'Provider',
+                    done: function(){},
+                    port: 1234,
+                    host: '1.2.3.4'
+                };
+
+                var createMockService = function() {
+                    Pact.mockService(options)
+                };
+
+                expect(createMockService).not.toThrow();
+            });
+        });
+    });
+});

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -3,7 +3,13 @@ Pact.MockService = Pact.MockService || {};
 (function() {
 
   function MockService(opts) {
-    var _baseURL = 'http://127.0.0.1:' + opts.port;
+
+    if (!opts || typeof(opts.port) === 'undefined' ) {
+      throw new Error('Error creating MockService. Please provide the Pact mock service port');
+    }
+
+    var _host = opts.host || '127.0.0.1';
+    var _baseURL = 'http://' + _host + ':' + opts.port;
     var _interactions = [];
     var self = this;
 


### PR DESCRIPTION
Thought it would be a good idea to support a paramaterised 'hosts' option - but it looks like @adbrowne beat us to it! - in the meanwhile, we wrote some tests around the configuration side of things that might be good to accompany the change.