### PR TITLE
Add eachLike array flexible matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ example-*/tmp
 checkstyle.xml
 
 .idea
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       term-ansicolor (~> 1.0)
       thor
       webrick
-    pact-support (0.5.1)
+    pact-support (0.5.3)
       awesome_print (~> 1.1)
       find_a_port (~> 1.0.1)
       json
@@ -52,3 +52,6 @@ PLATFORMS
 
 DEPENDENCIES
   pact-mock_service (= 0.7.0)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -197,6 +197,49 @@ provider
 
 [flexible-matching]: https://github.com/realestate-com-au/pact/wiki/Regular-expressions-and-type-matching-with-Pact
 
+#### Match based on arrays
+
+Matching provides the ability to specify flexible length arrays. For example:
+
+```javascript
+Pact.Match.eachLike(obj, { min: 3 })
+```
+
+Where `obj` can be any javascript object, value or Pact.Match. It takes optional argument (`{ min: 3 }`) where min is greater than 0 and defaults to 1 if not provided. 
+
+Below is an example that uses all of the Pact Matchers.
+
+```javascript
+
+var somethingLike = Pact.Match.somethingLike;
+var term = Pact.Match.term;
+var eachLike = Pact.Match.eachLike;
+
+provider
+  .given('there is a product')
+  .uponReceiving("request for products")
+  .withRequest({
+    method: "get",
+    path: "/products",
+    query: {
+      category: "clothing"
+    }
+  })
+  .willRespondWith({
+    status: 200,
+    headers: {
+        'Content-Type': 'application/json'
+    },
+    body: {
+        "items":eachLike({
+            size: somethingLike(10),
+            colour: term("red|green|blue", {generates: "blue"}),
+            tag: eachLike(somethingLike("jumper"))
+        }, {min: 2})
+    }
+  });
+```
+
 ### Examples
 
 #### Web Example

--- a/dist/pact-consumer-js-dsl.js
+++ b/dist/pact-consumer-js-dsl.js
@@ -157,7 +157,7 @@ Pact.MockService = Pact.MockService || {};
 
   function MockService(opts) {
 
-    if (!opts || typeof(opts.port) === 'undefined' ) {
+    if (!opts || typeof opts.port === 'undefined' ) {
       throw new Error('Error creating MockService. Please provide the Pact mock service port');
     }
 
@@ -166,7 +166,7 @@ Pact.MockService = Pact.MockService || {};
     var _interactions = [];
     var self = this;
 
-    if (typeof(opts.done) !== 'function') {
+    if (typeof opts.done !== 'function') {
       throw new Error('Error creating MockService. Please provide an option called "done", that is a function that asserts (using your test framework of choice) that the first argument, error, is null.');
     }
 
@@ -261,8 +261,9 @@ Pact.Match = Pact.Match || {};
 
 (function() {
     this.term = function(term) {
-
-        if (!term || typeof(term.generate) === 'undefined' || typeof(term.matcher) === 'undefined' ) {
+        if (!term ||
+            typeof term.generate === 'undefined' ||
+            typeof term.matcher === 'undefined') {
             throw new Error('Error creating a Pact Term. Please provide an object containing \'generate\' and \'matcher\' properties');
         }
 
@@ -279,10 +280,26 @@ Pact.Match = Pact.Match || {};
         };
     };
 
-    this.somethingLike = function(value) {
+    this.eachLike = function(content, options) {
+        if(typeof content === 'undefined') {
+            throw new Error('Error creating a Pact eachLike. Please provide a content argument');
+        }
 
-        if (typeof(value) === 'undefined' || typeof(value) === 'function') {
-            throw new Error('Error creating a Pact SomethingLike Match. Value cannot be a function or undefined');
+        if(options && !options.min) {
+            throw new Error('Error creating a Pact eachLike. Please provide options.min that is > 1');
+        }
+        
+        return {
+            'json_class': 'Pact::ArrayLike',
+            'contents': content,
+            'min': (!options) ? 1 : options.min
+        };
+    } ;
+
+    this.somethingLike = function(value) {
+        if (typeof value === 'undefined' ||
+            typeof value === 'function') {
+            throw new Error('Error creating a Pact somethingLike Match. Value cannot be a function or undefined');
         }
 
         return {

--- a/example/web/client-spec.js
+++ b/example/web/client-spec.js
@@ -61,9 +61,9 @@
               "Content-Type": "application/json"
             },
             body: {
-              friends: [{
+              friends: Pact.Match.eachLike({
                 name: Pact.Match.somethingLike('Sue') // Doesn't tie the Provider to a particular friend such as 'Sue'
-              }]
+              }, {min: 1})
             }
           });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -147,6 +147,10 @@ gulp.task('run-node-tests', ['build'], function () {
     });
 });
 
+gulp.task('run-integration-tests', function(callback){
+    runSequence('run-browser-tests-pact2', 'run-browser-tests', callback);
+});
+
 gulp.task('run-tests', function(callback){
 	runSequence('run-unit-tests', 'run-browser-tests', 'run-browser-tests-pact2', 'run-node-tests', callback);
 });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "scripts": {
     "test": "gulp run-tests",
-    "unit-test": "gulp run-unit-tests"
+    "unit-test": "gulp run-unit-tests",
+    "integration-test": "gulp run-integration-tests"
   },
   "repository": {
     "type": "git",

--- a/spec/integration/v2/match_spec.js
+++ b/spec/integration/v2/match_spec.js
@@ -1,0 +1,83 @@
+'use strict';
+
+describe('Match integration test', function() {
+
+    var doneCallback;
+    var mockService;
+    var somethingLike = Pact.Match.somethingLike;
+    var term = Pact.Match.term;
+    var eachLike = Pact.Match.eachLike;
+
+    beforeEach(function() {
+        doneCallback = jasmine.createSpy('doneCallback').and.callFake(function (error) {
+            expect(error).toBe(null);
+        });
+
+        mockService = Pact.mockService({
+            consumer: 'Consumer',
+            provider: 'Provider',
+            port: 1234,
+            done: doneCallback
+        });
+    });
+
+    describe('object with multiple Pact.Matchers', function () {
+        it('should respond with correct object', function(done) {
+
+            var doHttpCall = function(callback) {
+                specHelper.makeRequest({
+                    method: 'POST',
+                    path: '/thing',
+                    headers: {
+                        'Content-Type': 'text/plain'
+                    },
+                    body: 'body'
+                }, callback);
+            };
+
+            mockService
+                .uponReceiving('a request with Pact.Match eachLike, somethingLike and term')
+                .withRequest({
+                    method: 'POST',
+                    path: '/thing',
+                    headers: {
+                        'Content-Type': 'text/plain'
+                    },
+                    body: 'body'
+                })
+                .willRespondWith({
+                    status: 200,
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: {
+                        "items":eachLike({
+                            size: somethingLike(10),
+                            colour: term({generate: "red", matcher: "red|green|blue"}),
+                            tag: eachLike(
+                                somethingLike("jumper")
+                            , {min: 1})
+                        }, {min: 2})
+                    }
+                });
+
+            mockService.run(done, function(runComplete) {
+                doHttpCall(function (error, response) {
+                    expect(error).toBe(null, 'error');
+                    expect(JSON.parse(response.responseText)).toEqual(
+                        {
+                            items: [
+                                { size: 10, colour: 'red', tag: [ 'jumper' ] },
+                                { size: 10, colour: 'red', tag: [ 'jumper' ] }
+                            ]
+                        }
+                    );
+                    expect(response.status).toEqual(200, 'status');
+                    expect(response.getResponseHeader('Content-Type')).toEqual('application/json', 'Content-Type header');
+                    runComplete();
+                });
+            });
+        });
+
+    });
+});

--- a/spec/integration/v2/mock_service_spec.js
+++ b/spec/integration/v2/mock_service_spec.js
@@ -4,6 +4,7 @@ describe('MockService', function() {
   var doneCallback, mockService;
 
   beforeEach(function() {
+
     doneCallback = jasmine.createSpy('doneCallback').and.callFake(function (error) {
       expect(error).toBe(null);
     });
@@ -19,6 +20,7 @@ describe('MockService', function() {
   describe("a successful match using Pact Matchers", function() {
 
     describe("with an argument list", function() {
+
         var doHttpCall = function(callback) {
           specHelper.makeRequest({
             body: 'body',

--- a/spec/unit/match_spec.js
+++ b/spec/unit/match_spec.js
@@ -1,9 +1,16 @@
 'use strict';
 
-describe('Match', function () {
-    describe('term', function () {
-        describe('when provided a term', function () {
-            it('should return a serialized Ruby object', function () {
+describe('Match', function() {
+
+    //create alias
+    var somethingLike = Pact.Match.somethingLike;
+    var term = Pact.Match.term;
+    var eachLike = Pact.Match.eachLike;
+
+
+    describe('term', function() {
+        describe('when provided a term', function() {
+            it('should return a serialized Ruby object', function() {
                 var expected = {
                     "json_class": "Pact::Term",
                     "data": {
@@ -16,29 +23,29 @@ describe('Match', function () {
                     }
                 };
 
-                var term = Pact.Match.term({
+                var match = term({
                     generate: "myawesomeword",
                     matcher: "\\w+"
                 });
 
-                expect(term).toEqual(expected);
+                expect(match).toEqual(expected);
             });
         });
 
-        describe("when not provided with a valid term", function () {
+        describe("when not provided with a valid term", function() {
             var createTheTerm = function (badArg) {
                 return function () {
-                    Pact.Match.term(badArg);
+                    term(badArg);
                 }
             };
 
-            describe("when no term is provided", function () {
-                it("should throw an Error", function () {
+            describe("when no term is provided", function() {
+                it("should throw an Error", function() {
                     expect(createTheTerm()).toThrow();
                 });
             });
 
-            describe("when an invalid term is provided", function () {
+            describe("when an invalid term is provided", function() {
                 it("should throw an Error", function () {
                     expect(createTheTerm({})).toThrow();
                     expect(createTheTerm("")).toThrow();
@@ -50,37 +57,256 @@ describe('Match', function () {
     });
 
     describe('somethingLike', function () {
-        describe('when provided a value', function () {
-            it('should return a serialized Ruby object', function () {
+        describe('when provided a value', function() {
+            it('should return a serialized Ruby object', function() {
                 var expected = {
                     "json_class": "Pact::SomethingLike",
                     "contents": "myspecialvalue"
                 };
 
-                var match = Pact.Match.somethingLike("myspecialvalue");
+                var match = somethingLike("myspecialvalue");
                 expect(match).toEqual(expected);
             });
         });
 
-        describe("when not provided with a valid value", function () {
+        describe("when not provided with a valid value", function() {
             var createTheValue = function (badArg) {
                 return function () {
-                    Pact.Match.somethingLike(badArg);
+                    somethingLike(badArg);
                 }
             };
 
-            describe("when no value is provided", function () {
-                it("should throw an Error", function () {
+            describe("when no value is provided", function() {
+                it("should throw an Error", function() {
                     expect(createTheValue()).toThrow();
                 });
             });
 
-            describe("when an invalid value is provided", function () {
-                it("should throw an Error", function () {
+            describe("when an invalid value is provided", function() {
+                it("should throw an Error", function() {
                     expect(createTheValue(undefined)).toThrow();
                     expect(createTheValue(function(){})).toThrow();
                 });
             });
         });
     });
+
+    describe('eachLike', function() {
+        describe('when content is null', function() {
+            it('should provide null as contents', function() {
+                var expected = {
+                    "json_class": "Pact::ArrayLike",
+                    "contents": null,
+                    "min": 1
+                };
+
+                var match = eachLike(null, {min: 1});
+                expect(match).toEqual(expected);
+            });
+        });
+
+        describe('when an object is provided', function() {
+            it('should provide the object as contents', function() {
+                var expected = {
+                    "json_class": "Pact::ArrayLike",
+                    "contents": {a:1},
+                    "min": 1
+                };
+
+                var match = eachLike({a: 1}, {min: 1});
+                expect(match).toEqual(expected);
+            });
+        });
+
+        describe('when object.min is invalid', function() {
+            it('should throw an error message', function() {
+                expect(function() {
+                    eachLike({a: 1}, {min: 0});
+                }).toThrow();
+
+                expect(function() {
+                    eachLike({a: 1}, {min: null});
+                }).toThrow();
+            });
+        });
+
+        describe('when an array is provided', function() {
+            it('should provide the array as contents', function() {
+                var expected = {
+                    "json_class": "Pact::ArrayLike",
+                    "contents": [1,2,3],
+                    "min": 1
+                };
+
+                var match = eachLike([1,2,3], {min: 1});
+                expect(match).toEqual(expected);
+            });
+        });
+
+        describe('when a value is provided', function() {
+            it('should add the value in contents', function() {
+                var expected = {
+                    "json_class": "Pact::ArrayLike",
+                    "contents": "test",
+                    "min": 1
+                };
+
+                var match = eachLike("test", {min: 1});
+                expect(match).toEqual(expected);
+            });
+        });
+
+        describe('when the content has Pact.Macters', function() {
+            describe('of type somethingLike', function() {
+                it('should nest somethingLike correctly', function() {
+                    var expected = {
+                        "json_class": "Pact::ArrayLike",
+                        "contents": {
+                            "id": {
+                                "json_class": "Pact::SomethingLike",
+                                "contents": 10
+                            }
+                        },
+                        "min": 1
+                    };
+
+                    var match = eachLike({ id: somethingLike(10) }, {min: 1});
+                    expect(match).toEqual(expected);
+                });
+            });
+
+            describe('of type term', function() {
+                it('should nest term correctly', function() {
+                    var expected = {
+                        "json_class": "Pact::ArrayLike",
+                        "contents": {
+                            "colour": {
+                                "json_class": "Pact::Term",
+                                "data": {
+                                    "generate": "red",
+                                    "matcher": {
+                                        "json_class": "Regexp",
+                                        "o": 0,
+                                        "s": "red|green"
+                                    }
+                                }
+                            }
+                        },
+                        "min": 1
+                    };
+
+                    var match = eachLike({
+                        colour: term({
+                            generate: 'red',
+                            matcher: 'red|green'
+                        })
+                    }, {min: 1});
+
+                    expect(match).toEqual(expected);
+                });
+            });
+
+            describe('of type eachLike', function() {
+                it('should nest eachlike in contents', function() {
+                    var expected = {
+                        "json_class": "Pact::ArrayLike",
+                        "contents": {
+                            "json_class": "Pact::ArrayLike",
+                            "contents": "blue",
+                            "min": 1
+                        },
+                        "min": 1
+                    };
+
+                    var match = eachLike(eachLike("blue", {min: 1}), {min: 1});
+                    expect(match).toEqual(expected);
+                });
+            });
+
+            describe('complex object with multiple Pact.Matchers', function() {
+                it('should nest objects correctly', function() {
+                    var expected = {
+                        "json_class": "Pact::ArrayLike",
+                        "contents": {
+                            "json_class": "Pact::ArrayLike",
+                            "contents": {
+                                "size": {
+                                    "json_class": "Pact::SomethingLike",
+                                    "contents": 10
+                                },
+                                "colour": {
+                                    "json_class": "Pact::Term",
+                                    "data": {
+                                        "generate": "red",
+                                        "matcher": {
+                                            "json_class": "Regexp",
+                                            "o": 0,
+                                            "s": "red|green|blue"
+                                        }
+                                    }
+                                },
+                                "tag": {
+                                    "json_class": "Pact::ArrayLike",
+                                    "contents": [
+                                        {
+                                            "json_class": "Pact::SomethingLike",
+                                            "contents": "jumper"
+                                        },
+                                        {
+                                            "json_class": "Pact::SomethingLike",
+                                            "contents": "shirt"
+                                        }
+                                    ],
+                                    "min": 2
+                                }
+                            },
+                            "min": 1
+                        },
+                        "min": 1
+                    };
+
+                    var match = eachLike(
+                                    eachLike({
+                                        size: somethingLike(10),
+                                        colour: term({generate: "red", matcher: "red|green|blue"}),
+                                        tag: eachLike([
+                                                somethingLike("jumper"),
+                                                somethingLike("shirt")
+                                            ], {min: 2})
+                                        }, {min: 1}),
+                                    {min: 1});
+
+                    expect(match).toEqual(expected);
+                });
+            });
+        });
+
+        describe('When no options.min is not provided', function() {
+            it('should default to a min of 1', function () {
+                var expected = {
+                    "json_class": "Pact::ArrayLike",
+                    "contents": {a: 1},
+                    "min": 1
+                };
+
+                var match = eachLike({a: 1});
+                expect(match).toEqual(expected);
+            });
+        });
+
+        describe('When a options.min is provided', function() {
+            it('should provide the object as contents', function() {
+                var expected = {
+                    "json_class": "Pact::ArrayLike",
+                    "contents": {a: 1},
+                    "min": 3
+                };
+
+                var match = eachLike({a: 1}, {min: 3});
+                expect(match).toEqual(expected);
+            });
+        });
+
+    });
+
 });

--- a/src/match.js
+++ b/src/match.js
@@ -2,8 +2,9 @@ Pact.Match = Pact.Match || {};
 
 (function() {
     this.term = function(term) {
-
-        if (!term || typeof(term.generate) === 'undefined' || typeof(term.matcher) === 'undefined' ) {
+        if (!term ||
+            typeof term.generate === 'undefined' ||
+            typeof term.matcher === 'undefined') {
             throw new Error('Error creating a Pact Term. Please provide an object containing \'generate\' and \'matcher\' properties');
         }
 
@@ -20,10 +21,26 @@ Pact.Match = Pact.Match || {};
         };
     };
 
-    this.somethingLike = function(value) {
+    this.eachLike = function(content, options) {
+        if(typeof content === 'undefined') {
+            throw new Error('Error creating a Pact eachLike. Please provide a content argument');
+        }
 
-        if (typeof(value) === 'undefined' || typeof(value) === 'function') {
-            throw new Error('Error creating a Pact SomethingLike Match. Value cannot be a function or undefined');
+        if(options && !options.min) {
+            throw new Error('Error creating a Pact eachLike. Please provide options.min that is > 1');
+        }
+        
+        return {
+            'json_class': 'Pact::ArrayLike',
+            'contents': content,
+            'min': (!options) ? 1 : options.min
+        };
+    } ;
+
+    this.somethingLike = function(value) {
+        if (typeof value === 'undefined' ||
+            typeof value === 'function') {
+            throw new Error('Error creating a Pact somethingLike Match. Value cannot be a function or undefined');
         }
 
         return {

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -4,7 +4,7 @@ Pact.MockService = Pact.MockService || {};
 
   function MockService(opts) {
 
-    if (!opts || typeof(opts.port) === 'undefined' ) {
+    if (!opts || typeof opts.port === 'undefined' ) {
       throw new Error('Error creating MockService. Please provide the Pact mock service port');
     }
 
@@ -13,7 +13,7 @@ Pact.MockService = Pact.MockService || {};
     var _interactions = [];
     var self = this;
 
-    if (typeof(opts.done) !== 'function') {
+    if (typeof opts.done !== 'function') {
       throw new Error('Error creating MockService. Please provide an option called "done", that is a function that asserts (using your test framework of choice) that the first argument, error, is null.');
     }
 


### PR DESCRIPTION
Added Pact.Match.eachLike matcher.

Note: this build will not pass until https://github.com/bethesque/pact-support/pull/10 has been incorporated into the next gem versions (pact-support and pact-mock-service) and we update the Gemfile. 

cc: @mefellows 