### PR TITLE
Clarify example to cause a pact file to be written

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ gem 'pact-mock_service', '~> 0.7.0'
 
 1. Let's run that bad boy!
 
-   * Start the pact mock server with `bundle exec pact-mock-service -p 1234 --pact-specification-version 2.0.0 -l log/pact.logs --pact-dir tmp/pacts`
+   * Start the pact mock server with `bundle exec pact-mock-service -p 1234 --pact-specification-version 2.0.0 -l log/pact.logs --consumer=hello_consumer --provider=hello_provider --pact-dir tmp/pacts`
    * Run `karma start` (in another terminal window)
    * Inspect the pact file that has been written to "hello_consumer-hello_provider.json"
 


### PR DESCRIPTION
Without all three of the `--consumer`, `--producer`, and `--pact-dir` flags, it appears that the mock service won't actually write a pact file on shutdown.

I spelunked the source of `pact-mock-provider` a while scratching my head on why I wasn't getting anything written.