### PR TITLE
Added `.resetSession` to allow clearing out pact-mock-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ gem 'pact-mock_service', '~> 0.7.0'
     describe("Client", function() {
       var client, helloProvider;
 
-      beforeEach(function() {
+      beforeAll(function(done) {
         //ProviderClient is the class you have written to make the HTTP calls to the provider
         client = new ProviderClient('http://localhost:1234');
         helloProvider = Pact.mockService({
@@ -94,6 +94,10 @@ gem 'pact-mock_service', '~> 0.7.0'
             expect(error).toBe(null);
           }
         });
+
+        // This ensures your pact-mock-service is in a clean state before
+        // running your test suite.
+        helloProvider.resetSession(done);
       });
 
       it("should say hello", function(done) {

--- a/dist/pact-consumer-js-dsl.js
+++ b/dist/pact-consumer-js-dsl.js
@@ -150,7 +150,12 @@ Pact.MockServiceRequests = Pact.MockServiceRequests || {};
     Pact.Http.makeRequest('POST', baseUrl + '/pact', JSON.stringify(pactDetails), createResponseHandler('Could not write the pact file', callback));
   };
 
+  this.deleteSession = function(baseUrl, callback) {
+    Pact.Http.makeRequest('DELETE', baseUrl + '/session', null, createResponseHandler('Pact session cleanup failed', callback));
+  };
+
 }).apply(Pact.MockServiceRequests);
+
 Pact.MockService = Pact.MockService || {};
 
 (function() {
@@ -206,6 +211,13 @@ Pact.MockService = Pact.MockService || {};
         callback = callback || function(){};
         //Verify that the expected interactions have occurred
         Pact.MockServiceRequests.getVerification(_baseURL, callback);
+    };
+
+    this.resetSession = function(callback) {
+        callback = callback || function(){};
+        // DELETE the existing session so the developer can modify pacts without
+        // to restarting the server.
+        Pact.MockServiceRequests.deleteSession(_baseURL, callback);
     };
 
     this.write = function(callback) {

--- a/spec/unit/mock_service_reset_session_spec.js
+++ b/spec/unit/mock_service_reset_session_spec.js
@@ -1,0 +1,44 @@
+'use strict';
+
+describe('MockService', function() {
+
+  describe("resetSession", function () {
+
+    var mockService;
+
+    beforeEach(function () {
+      mockService = Pact.mockService({
+        consumer: 'Consumer',
+        provider: 'Provider',
+        port: 1234,
+        done: function() {}
+      });
+    });
+
+    describe("when there are no errors", function () {
+      it("invokes the passed in callback with null", function (done) {
+        spyOn(Pact.MockServiceRequests, 'deleteSession').and.callFake(function( baseUrl, callback){
+          callback(null);
+        });
+
+        mockService.resetSession(function (error) {
+          expect(error).toBe(null);
+          done();
+        });
+      });
+    });
+
+    describe("when there is an error setting up the new interactions", function () {
+      it("invokes the passed in callback with the error", function (done) {
+        spyOn(Pact.MockServiceRequests, 'deleteSession').and.callFake(function( baseUrl, callback){
+          callback("Sorry, didn't work");
+        });
+
+        mockService.resetSession(function (error) {
+          expect(error).toBe("Sorry, didn't work");
+          done();
+        });
+      });
+    });
+  });
+});

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -55,6 +55,13 @@ Pact.MockService = Pact.MockService || {};
         Pact.MockServiceRequests.getVerification(_baseURL, callback);
     };
 
+    this.resetSession = function(callback) {
+        callback = callback || function(){};
+        // DELETE the existing session so the developer can modify pacts without
+        // to restarting the server.
+        Pact.MockServiceRequests.deleteSession(_baseURL, callback);
+    };
+
     this.write = function(callback) {
         callback = callback || function(){};
         Pact.MockServiceRequests.postPact(_pactDetails, _baseURL, callback);

--- a/src/mockServiceRequests.js
+++ b/src/mockServiceRequests.js
@@ -35,4 +35,8 @@ Pact.MockServiceRequests = Pact.MockServiceRequests || {};
     Pact.Http.makeRequest('POST', baseUrl + '/pact', JSON.stringify(pactDetails), createResponseHandler('Could not write the pact file', callback));
   };
 
+  this.deleteSession = function(baseUrl, callback) {
+    Pact.Http.makeRequest('DELETE', baseUrl + '/session', null, createResponseHandler('Pact session cleanup failed', callback));
+  };
+
 }).apply(Pact.MockServiceRequests);


### PR DESCRIPTION
I usually like leave my pact-mock-service instance running as I develop my pact tests. However, if I tweak a pact test I end up with the following error and have to restart my server.

```
pact-consumer-js-dsl: Pact interaction setup failed
An interaction with same description ("a sample request") and provider state ("the server is can handle a sample request") but a different response body has already been use d. Please use a different description or provider state.
```

This change allows me to call `provider.resetSession` in a `beforeAll` block and make sure pact-mock-service is in a clean state before running my test suite.
